### PR TITLE
Resources should not be considered complete if their abstract contains t...

### DIFF
--- a/lib/restfully/media_type/application_vnd_bonfire_xml.rb
+++ b/lib/restfully/media_type/application_vnd_bonfire_xml.rb
@@ -195,7 +195,7 @@ module Restfully
       end
       
       def complete?
-        if property.reject{|k,v| [HIDDEN_TYPE_KEY, "id", "name"].include?(k)}.empty? && links.find(&:self?)
+        if property.reject{|k,v| [HIDDEN_TYPE_KEY, "id", "name", "type"].include?(k)}.empty? && links.find(&:self?)
           false
         else
           true


### PR DESCRIPTION
...ype information

<metric href=\"/locations/fr-inria/locationmetrics/aliases/Availability\" name=\"Availability\" type=\"application/vnd.bonfire+xml\">\n    </metric> as fragment should not be seen as a complete description of the resource.
