### PR TITLE
Offer a means of getting resources included in large paged collections

### DIFF
--- a/spec/fixtures/bonfire-experiment-collection.xml
+++ b/spec/fixtures/bonfire-experiment-collection.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <collection xmlns="http://api.bonfire-project.eu/doc/schemas/occi" href="/experiments">
-  <items offset="0" total="3">
+  <items offset="0" total="4">
 <experiment href="/experiments/1">
   <id>1</id>
   <description>Experiment description</description>

--- a/spec/restfully/collection_spec.rb
+++ b/spec/restfully/collection_spec.rb
@@ -97,6 +97,23 @@ describe Restfully::Collection do
       }
       @resource[:'3'].should_not be_nil
     end
+    it "should not find an item by uid if on the second page and guess_paged_items false" do
+      @session.config[:guess_paged_items]=false
+      @resource[:'4'].should be_nil
+    end
+
+    it "should find an item by uid if on the second page and guess_paged_items is true" do
+      @session.config[:guess_paged_items]=true
+      @session.should_receive(:get).and_return(@resource)
+      @resource[:'4'].should_not be_nil
+    end
+
+    it "should not find an item by uid if on the second page, guess_paged_items is true and item does not exist" do
+      @session.config[:guess_paged_items]=true
+      @session.should_receive(:get).and_raise(Restfully::HTTP::ClientError)
+      @resource[:'5'].should be_nil
+    end
+
   end
 
   

--- a/spec/restfully/media_type/application_vnd_bonfire_xml_spec.rb
+++ b/spec/restfully/media_type/application_vnd_bonfire_xml_spec.rb
@@ -99,7 +99,7 @@ describe Restfully::MediaType::ApplicationVndBonfireXml do
       collection.uri.to_s.should == "http://localhost:8000/experiments"
       collection.collection?.should be_true
       collection.length.should == 3
-      collection.total.should == 3
+      collection.total.should == 4
       collection.offset.should == 0
       collection.all?{|i| i.kind_of? Restfully::Resource}.should be_true
       collection[0].should == collection.first


### PR DESCRIPTION
When looking for a specific resource in a collection, allow guessing the url of the resource if configured to do so and the link to the resource is not on the first page of the collection.

This is to get to a particular job whose id has been saved, but no longer appears in the list of jobs on the first page of the jobs collection in Grid'5000 for example.

Depends on the :guess_paged_items option given when creating the session.