### PR TITLE
Optimize single item retrieval from collection, using direct fetch when possible

### DIFF
--- a/lib/restfully/collection.rb
+++ b/lib/restfully/collection.rb
@@ -16,7 +16,11 @@ module Restfully
     end
 
     def find_by_uid(symbol)
-      found = find{ |i| i.media_type.represents?(symbol) }
+      direct_uri = media_type.direct_fetch_uri(symbol)
+      # Attempt to make a direct fetch if possible (in case of large collections)
+      found = session.get(direct_uri) if direct_uri
+      # Fall back to collection traversal if direct fetch was not possible, or was not found
+      found = find{ |i| i.media_type.represents?(symbol) } if found.nil?
       found.expand unless found.nil?
       found
     end

--- a/lib/restfully/media_type/abstract_media_type.rb
+++ b/lib/restfully/media_type/abstract_media_type.rb
@@ -86,6 +86,13 @@ module Restfully
         @session = session
       end
 
+      # Returns a direct URI to a specific resource identified by <tt>symbol</tt>.
+      # Only called from collections, when doing collection[:'some-resource-id'].
+      # Either return a path if the media type supports direct fetching, or nil (default).
+      def direct_fetch_uri(symbol)
+        nil
+      end
+
       # Returns an array of Link objects.
       # Do not overwrite directly. Overwrite #extract_links instead.
       def links

--- a/lib/restfully/media_type/grid5000.rb
+++ b/lib/restfully/media_type/grid5000.rb
@@ -46,6 +46,12 @@ module Restfully
         !!(property("items") && property("total") && property("offset"))
       end
 
+      def direct_fetch_uri(symbol)
+        self_link = links.find{|l| l.self?}
+        return nil if self_link.nil?
+        URI.parse([self_link.href, symbol.to_s].join("/"))
+      end
+
       def meta
         if collection?
           property("items")


### PR DESCRIPTION
Alternate option for issue discussed in #8. Not tested (I don't have access to Grid5000 API), but hopefully it should work.