### PR TITLE
Requesting an more appropriate Content-Type when requesting using direct_fetch_uri

### DIFF
--- a/lib/restfully/collection.rb
+++ b/lib/restfully/collection.rb
@@ -16,9 +16,9 @@ module Restfully
     end
 
     def find_by_uid(symbol)
-      direct_uri,options = media_type.direct_fetch_uri(symbol)
+      direct_uri = media_type.direct_fetch_uri(symbol)
       # Attempt to make a direct fetch if possible (in case of large collections)
-      found = session.get(direct_uri,options) if direct_uri
+      found = session.get(direct_uri,{:head => {'Accept' => media_type.class.default_type}}) if direct_uri
       # Fall back to collection traversal if direct fetch was not possible, or was not found
       found = find{ |i| i.media_type.represents?(symbol) } if found.nil?
       found.expand unless found.nil?

--- a/lib/restfully/collection.rb
+++ b/lib/restfully/collection.rb
@@ -16,9 +16,9 @@ module Restfully
     end
 
     def find_by_uid(symbol)
-      direct_uri = media_type.direct_fetch_uri(symbol)
+      direct_uri,options = media_type.direct_fetch_uri(symbol)
       # Attempt to make a direct fetch if possible (in case of large collections)
-      found = session.get(direct_uri) if direct_uri
+      found = session.get(direct_uri,options) if direct_uri
       # Fall back to collection traversal if direct fetch was not possible, or was not found
       found = find{ |i| i.media_type.represents?(symbol) } if found.nil?
       found.expand unless found.nil?

--- a/lib/restfully/media_type/grid5000.rb
+++ b/lib/restfully/media_type/grid5000.rb
@@ -49,7 +49,9 @@ module Restfully
       def direct_fetch_uri(symbol)
         self_link = links.find{|l| l.self?}
         return nil if self_link.nil?
-        URI.parse([self_link.href, symbol.to_s].join("/"))
+        return URI.parse([self_link.href, symbol.to_s].join("/")), {:head => {
+            'Accept' =>  "application/vnd.grid5000.item+json",
+          }}
       end
 
       def meta

--- a/lib/restfully/media_type/grid5000.rb
+++ b/lib/restfully/media_type/grid5000.rb
@@ -49,9 +49,7 @@ module Restfully
       def direct_fetch_uri(symbol)
         self_link = links.find{|l| l.self?}
         return nil if self_link.nil?
-        return URI.parse([self_link.href, symbol.to_s].join("/")), {:head => {
-            'Accept' =>  "application/vnd.grid5000.item+json",
-          }}
+        URI.parse([self_link.href, symbol.to_s].join("/"))
       end
 
       def meta

--- a/spec/restfully/collection_spec.rb
+++ b/spec/restfully/collection_spec.rb
@@ -99,5 +99,19 @@ describe Restfully::Collection do
     end
   end
 
-  
+  describe "direct_fetch_usage" do
+    it "should attempt a direct_fetch using default type for media_type" do
+      @response.media_type.class.should == Restfully::MediaType::Grid5000
+      direct_uri="https://api.project.net/fake_stub"
+      direct_uri=@response.media_type.should_receive(:direct_fetch_uri).and_return(direct_uri)
+      Restfully::MediaType::Grid5000.should_receive(:default_type).and_return('test/fake+json')
+      stub_request(:get, "https://api.project.net/fake_stub").
+        with(:headers => {'Accept'=>'test/fake+json'}).
+        to_return(:status => 200,
+                  :body => fixture('grid5000-rennes-job.json'),
+                  :headers => {'Content-Type' => 'application/json'})
+      @resource.load
+      @resource[:'3'].should_not be_nil
+    end
+  end
 end


### PR DESCRIPTION
When requesting an item from a collection using direct_fetch_uri using the grid5000 media-type, no attempt is made at setting an appropriate Accept header.

This pull request to illustrate the issue, with an unsatisfactory solution and no unit tests.

Any ideas ?

David 
