### PR TITLE
Update gemspec to specify old versions of gems when using old versions of ruby

### DIFF
--- a/restfully.gemspec
+++ b/restfully.gemspec
@@ -20,9 +20,19 @@ Gem::Specification.new do |s|
   s.add_dependency('json', '~> 1.5')
   s.add_dependency('rest-client', '~> 1.6')
   s.add_dependency('rest-client-components')
-  s.add_dependency('rack-cache')
+  if RUBY_VERSION < "1.9.3"
+    s.add_dependency('rack-cache', '~> 1.2.0')
+  else
+    s.add_dependency('rack-cache')
+  end
+  s.add_dependency('rack', '~> 1.6') if RUBY_VERSION < "2.2.2"
   s.add_dependency('backports')
   s.add_dependency('addressable')
+  if RUBY_VERSION < "1.9.3"
+    s.add_dependency('public_suffix', '~> 1.3.0') 
+  elsif RUBY_VERSION < "2.0"
+    s.add_dependency('public_suffix', '~> 1.4.0') 
+  end
   s.add_dependency('ripl', '0.6.1')
   s.add_dependency('ripl-multi_line')
   s.add_dependency('ripl-color_streams')
@@ -32,7 +42,11 @@ Gem::Specification.new do |s|
   
   s.add_development_dependency('rake', '~> 0.8')
   s.add_development_dependency('rspec', '~> 2')
-  s.add_development_dependency('webmock')
+  if RUBY_VERSION < "1.9.3"
+    s.add_development_dependency('webmock', '~> 1.20.4')
+  else
+    s.add_development_dependency('webmock')
+  end
   s.add_development_dependency('autotest')
   s.add_development_dependency('autotest-growl')
   


### PR DESCRIPTION
This PR will still require work to understand whether we really want to continue supporting restfully on old rubies