### PR TITLE
Finish updating the gemspec ; correct failing unit test du to updated webmock if using ruby > 2.0

### DIFF
--- a/restfully.gemspec
+++ b/restfully.gemspec
@@ -34,9 +34,12 @@ Gem::Specification.new do |s|
   s.add_dependency('addressable')
   if RUBY_VERSION < "1.9.3"
     s.add_dependency('mime-types', '~> 2.6.0') 
+  else
+    s.add_dependency('mime-types') 
+  end
+  if RUBY_VERSION < "1.9.3"
     s.add_dependency('public_suffix', '~> 1.3.0') 
   elsif RUBY_VERSION < "2.0"
-    s.add_dependency('mime-types') 
     s.add_dependency('public_suffix', '~> 1.4.0') 
   end
   s.add_dependency('ripl', '0.6.1')

--- a/restfully.gemspec
+++ b/restfully.gemspec
@@ -18,7 +18,11 @@ Gem::Specification.new do |s|
   s.description               = "Consume RESTful APIs effortlessly"
   
   s.add_dependency('json', '~> 1.5')
-  s.add_dependency('rest-client', '~> 1.6')
+  if RUBY_VERSION < "2.0.0"
+    s.add_dependency('rest-client', '< 2.0')
+  else
+    s.add_dependency('rest-client')
+  end
   s.add_dependency('rest-client-components')
   if RUBY_VERSION < "1.9.3"
     s.add_dependency('rack-cache', '~> 1.2.0')
@@ -29,8 +33,10 @@ Gem::Specification.new do |s|
   s.add_dependency('backports')
   s.add_dependency('addressable')
   if RUBY_VERSION < "1.9.3"
+    s.add_dependency('mime-types', '~> 2.6.0') 
     s.add_dependency('public_suffix', '~> 1.3.0') 
   elsif RUBY_VERSION < "2.0"
+    s.add_dependency('mime-types') 
     s.add_dependency('public_suffix', '~> 1.4.0') 
   end
   s.add_dependency('ripl', '0.6.1')

--- a/spec/restfully/session_spec.rb
+++ b/spec/restfully/session_spec.rb
@@ -155,12 +155,22 @@ describe Restfully::Session do
     end
 
     it "should make an authenticated get request" do
-      stub_request(:get, "https://crohr:p4ssw0rd@api.project.net"+@path+"?k1=v1&k2=v2").with(
-        :headers => @default_headers.merge({
-          'Accept' => '*/*',
-          'X-Header' => 'value'
-        })
-      )
+      if ::WebMock::VERSION >= "2.0.0"
+        stub_request(:get, "https://api.project.net"+@path+"?k1=v1&k2=v2").with(
+          :basic_auth => ['crohr','p4ssw0rd'],
+          :headers => @default_headers.merge({
+            'Accept' => '*/*',
+            'X-Header' => 'value'
+          })
+        )
+      else
+        stub_request(:get, "https://crohr:p4ssw0rd@api.project.net"+@path+"?k1=v1&k2=v2").with(
+          :headers => @default_headers.merge({
+            'Accept' => '*/*',
+            'X-Header' => 'value'
+          })
+        )
+      end
       @session.should_receive(:process)
       @session.authenticate :username => 'crohr', :password => 'p4ssw0rd'
       @session.send(:transmit, :get, @path, {


### PR DESCRIPTION
See the important node in https://github.com/bblimke/webmock#request-with-basic-authentication-header for the update to unit tests.

Got to the point Grid'5000 bug #7533 that prompted the work on the gemset (no longer depend on rest-client 1.6)